### PR TITLE
adding password to mysqlslap parameter's

### DIFF
--- a/033-OSSDatabaseMigration/Coach/02-size-analysis.md
+++ b/033-OSSDatabaseMigration/Coach/02-size-analysis.md
@@ -34,5 +34,5 @@
     kubectl -n mysql exec deploy/mysql -it -- bash
     
     apt update ; apt install htop
-    mysqlslap -u root -p --concurrency=140 --iterations=50 --number-int-cols=10 --number-char-cols=20 --auto-generate-sql
+    mysqlslap -u root -pOCPHack8 --concurrency=140 --iterations=50 --number-int-cols=10 --number-char-cols=20 --auto-generate-sql
 ```


### PR DESCRIPTION
Otherwise it will prompt for it, example:
root@mysql-78cf679f8f-l4wlc:/# mysqlslap -u root -p --concurrency=140 --iterations=50 --number-int-cols=10 --number-char-cols=20 --auto-generate-sql
Enter password:
mysqlslap: Error when connecting to server: Access denied for user 'root'@'localhost' (using password: NO)